### PR TITLE
Fix utils.parse_email_addr() to strip trailing whitespaces in name

### DIFF
--- a/utils.lua
+++ b/utils.lua
@@ -70,7 +70,7 @@ end
 function M.parse_email_addr(addr)
     if not addr then return nil end
 
-    local name, email = addr:match('%s*(.*)%s*<([^>]+)>')
+    local name, email = addr:match('%s*(.-)%s*<([^>]+)>')
     email = email or addr:match('%S+@%S+')
 
     if M.is_valid_email(email) then


### PR DESCRIPTION
This is the cause of duplicate records in the `maintainer` table. I’m very sorry. I’m gonna prepare SQL query to fix it in the DB.
