### PR TITLE
Order referenced packages alphabetically on package detail page

### DIFF
--- a/db.lua
+++ b/db.lua
@@ -140,6 +140,7 @@ function db:getDepends(pkg)
         LEFT JOIN provides ON depends.name = provides.name
         LEFT JOIN packages ON provides.pid = packages.id
         WHERE packages.branch = :branch  AND packages.arch = :arch AND depends.pid = :id
+        ORDER BY packages.name
     ]]
     local stmt = self.db:prepare(sql)
     stmt:bind_names(pkg)
@@ -158,6 +159,7 @@ function db:getProvides(pkg)
         LEFT JOIN depends ON provides.name = depends.name
         LEFT JOIN packages ON depends.pid = packages.id
         WHERE packages.branch = :branch  AND packages.arch = :arch AND provides.pid = :id
+        ORDER BY packages.name
     ]]
     local stmt = self.db:prepare(sql)
     stmt:bind_names(pkg)
@@ -173,7 +175,9 @@ end
 function db:getOrigins(pkg)
     local r = {}
     local sql = [[ SELECT DISTINCT packages.* FROM packages
-    WHERE branch = :branch AND repo = :repo AND arch = :arch AND origin = :origin ]]
+        WHERE branch = :branch AND repo = :repo AND arch = :arch AND origin = :origin
+        ORDER BY packages.name
+    ]]
     local stmt = self.db:prepare(sql)
     stmt:bind_names(pkg)
     for row in stmt:nrows(sql) do


### PR DESCRIPTION
The list of packages required or provided by a certain package is quite hard to grok when it's not ordered by name.

Looking for a certain package is unnecessarily hard, especially if the exact name is not known, so having the browser search the page is not an option. I have even overlooked packages because I didn't expect them to appear elsewhere in the list.

When packages are ordered by name, they are automatically grouped by prefix, which is also useful.

I (think I) implemented package ordering by name that with this patch, but I haven't been able to actually test it.