### PR TITLE
Update copyright and formatting

### DIFF
--- a/views/footer.tpl
+++ b/views/footer.tpl
@@ -1,5 +1,5 @@
     <footer>
-        <div>© Copyright 2016 Alpine Linux Development Team all rights reserved | <a href="http://www.alpinelinux.org/privacy-policy.html">Privacy Policy</a></div>
+        <div>© Copyright 2017 Alpine Linux Development Team, All rights reserved | <a href="http://www.alpinelinux.org/privacy-policy.html">Privacy Policy</a></div>
         <div>Please report issues for this service to its <a href="https://github.com/clandmeter/aports-turbo">Github project page</a></div>
     </footer>
     </body>


### PR DESCRIPTION
Bump year to 2017
Add comma before "All rights reserved"