### PR TITLE
Split databases into branches/flagged (and various)

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,6 @@
+std = "luajit"
+
+globals = { 
+	"class",
+	"TURBO_SSL"
+}

--- a/aports.lua
+++ b/aports.lua
@@ -5,7 +5,6 @@ local turbo = require("turbo")
 
 local conf  = require("config")
 local cntrl = require("controller")
-local db    = require("db")
 local utils = require("utils")
 
 local is_valid_email = utils.is_valid_email
@@ -13,42 +12,30 @@ local is_valid_email = utils.is_valid_email
 -- packages renderer to display a list of packages
 local packagesRenderer = class("packagesRenderer", turbo.web.RequestHandler)
 
-function packagesRenderer:prepare()
-    db:open()
-end
-
-function packagesRenderer:on_finish()
-    db:close()
-end
-
 function packagesRenderer:get()
     local args = {
-        name = self:get_argument("name","", true),
-        branch = self:get_argument("branch", "", true),
+        name = self:get_argument("name", "", true),
+        branch = self:get_argument("branch", conf.default.branch, true),
         arch = self:get_argument("arch", "", true),
         repo = self:get_argument("repo", "", true),
         maintainer = self:get_argument("maintainer", "", true),
         page = tonumber(self:get_argument("page", 1, true)) or 1,
     }
-    self:write(cntrl:packages(args))
+    if utils.in_table(args.branch, conf.branches) then
+        self:write(cntrl.packages(args))
+    else
+        error(turbo.web.HTTPError(404, "404 Page not found."))
+    end
 end
 
 -- package renderer, to display a single package
 local packageRenderer = class("packageRenderer", turbo.web.RequestHandler)
 
-function packageRenderer:prepare()
-    db:open()
-end
-
-function packageRenderer:on_finish()
-    db:close()
-end
-
 function packageRenderer:get(branch, repo, arch, name)
-    local ops = {branch=branch,repo=repo,arch=arch, name=name}
-    local pkg = cntrl:getPackage(ops)
-    if next(pkg) then
-        self:write(cntrl:package(pkg))
+    local pkg = cntrl.getPackage(branch, repo, arch, name)
+    if next(pkg) and utils.in_table(branch, conf.branches) then
+        pkg.branch = branch
+        self:write(cntrl.package(pkg))
     else
         error(turbo.web.HTTPError(404, "404 Page not found."))
     end
@@ -56,49 +43,38 @@ end
 
 local contentsRenderer = class("contentsRenderer", turbo.web.RequestHandler)
 
-function contentsRenderer:prepare()
-    db:open()
-end
-
-function contentsRenderer:on_finish()
-    db:close()
-end
-
 function contentsRenderer:get()
     local args = {
         file = self:get_argument("file", "", true),
         path = self:get_argument("path", "", true),
         name = self:get_argument("name", "", true),
-        branch = self:get_argument("branch", "", true),
+        branch = self:get_argument("branch", conf.default.branch, true),
         repo = self:get_argument("repo", "", true),
         arch = self:get_argument("arch", "", true),
         page = tonumber(self:get_argument("page", 1, true)) or 1,
     }
-    self:write(cntrl:contents(args))
-end
-
--- flagged renderer, to display the flag form
-local flagRenderer = class("flagRenderer", turbo.web.RequestHandler)
-
-function flagRenderer:prepare()
-    db:open()
-end
-
-function flagRenderer:on_finish()
-    db:close()
-end
-
-function flagRenderer:get(branch, repo, origin, version)
-    local ops = {branch=branch, repo=repo, origin=origin, version=version}
-    local pkg = cntrl:getNotFlagged(ops)
-    if pkg then
-        self:write(cntrl:flag(pkg))
+    if utils.in_table(args.branch, conf.branches) then
+        self:write(cntrl.contents(args))
     else
         error(turbo.web.HTTPError(404, "404 Page not found."))
     end
 end
 
-function flagRenderer:post(branch, repo, origin, version)
+-- flagged renderer, to display the flag form
+local flagRenderer = class("flagRenderer", turbo.web.RequestHandler)
+
+function flagRenderer:get(repo, origin, version)
+    local pkg = { origin = origin, repo = repo, version = version }
+    local exists = cntrl.isOrigin(conf.default.branch, repo, origin, version)
+    local flagged = cntrl.isFlagged(origin, repo, version)
+    if exists and not flagged then
+        self:write(cntrl.flag(pkg))
+    else
+        error(turbo.web.HTTPError(404, "404 Page not found."))
+    end
+end
+
+function flagRenderer:post(repo, origin, version)
     local m = {}
     local args = {
         from = self:get_argument("from", "", true),
@@ -106,68 +82,63 @@ function flagRenderer:post(branch, repo, origin, version)
         message = self:get_argument("message", "", true),
         responce = self:get_argument("g-recaptcha-response", "", true),
     }
-    local ops = { branch=branch, repo=repo, name=origin, version=version }
+    local pkg = { origin=origin, repo=repo, version=version }
     m.form = {value=args}
-    local pkg = cntrl:getNotFlagged(ops)
-    -- check if pkg exists and is not flagged
-    if not pkg then
+    if cntrl.isFlagged(origin, repo, version) then
         error(turbo.web.HTTPError(404, "404 Page not found."))
     -- check if email is valid
     elseif not is_valid_email(args.from) then
         m.form.status = {from="has-error"}
         m.alert = {type="danger",msg="Please provide a valid email address"}
-        self:write(cntrl:flag(pkg, m))
+        self:write(cntrl.flag(pkg, m))
     -- check if new version is provided
     elseif args.new_version == "" then
         m.form.status = {new_version="has-error"}
         m.alert = {type="danger",msg="Please provide a new upstream version number"}
-        self:write(cntrl:flag(pkg, m))
+        self:write(cntrl.flag(pkg, m))
     -- check if message is provided
     elseif args.message == "" then
         m.form.status = {message="has-error"}
         m.alert = {type="danger",msg="Please provide a message"}
-        self:write(cntrl:flag(pkg, m))
+        self:write(cntrl.flag(pkg, m))
     -- check if recaptcha is correct
-    elseif conf.rc.sitekey and not cntrl:verifyRecaptcha(args.responce) then
+    elseif conf.rc.sitekey and not cntrl.verifyRecaptcha(args.responce) then
         m.alert = {type="danger",msg="reCAPTCHA failed, please try again"}
-        self:write(cntrl:flag(pkg, m))
+        self:write(cntrl.flag(pkg, m))
     -- try to flag the package
-    elseif not db:flagOrigin(args, pkg) then
+    elseif not cntrl.flagOrigin(args, pkg) then
         m.alert = {type="danger",msg="Could not flag package, please try again"}
-        self:write(cntrl:flag(pkg, m))
+        self:write(cntrl.flag(pkg, m))
     -- successfully flagged, lets display the flagged origin package
     else
-        if is_valid_email(pkg.memail) then
-            cntrl:flagMail(args, pkg)
+        local maintainer = cntrl.getMaintainer(conf.default.branch, origin)
+        if maintainer and is_valid_email(maintainer.email) then
+            pkg.memail = maintainer.email
+            local r, e = cntrl.flagMail(args, pkg)
+            if not r then turbo.log.warning(e) end
         end
         m.alert = {type="success",msg="Succesfully flagged package"}
-        self:write(cntrl:package(pkg, m))
+        args = { origin = pkg.origin, repo = pkg.repo,
+            maintainer = maintainer.name, page = 1 }
+        self:write(cntrl.flagged(args, m))
     end
 end
 
 local flaggedRenderer = class("flaggedRenderer", turbo.web.RequestHandler)
 
-function flaggedRenderer:prepare()
-    db:open()
-end
-
-function flaggedRenderer:on_finish()
-    db:close()
-end
-
 function flaggedRenderer:get()
     local args = {
-        origin = self:get_argument("origin","", true),
-        branch = self:get_argument("branch", "", true),
+        origin = self:get_argument("origin", "", true),
         repo = self:get_argument("repo", "", true),
         maintainer = self:get_argument("maintainer", "", true),
         page = tonumber(self:get_argument("page", 1, true)) or 1,
     }
-    self:write(cntrl:flagged(args))
+    self:write(cntrl.flagged(args))
 end
 
-function cleanup(loop)
+local function cleanup(loop)
     turbo.log.notice("Stopping application.")
+    cntrl:cleanup()
     loop:close()
 end
 
@@ -176,11 +147,11 @@ turbo.web.Application({
     {"^/contents$", contentsRenderer},
     {"^/packages$", packagesRenderer},
     {"^/package/(.*)/(.*)/(.*)/(.*)$", packageRenderer},
-    {"^/flag/(.*)/(.*)/(.*)/(.*)$", flagRenderer},
+    {"^/flag/(.*)/(.*)/(.*)$", flagRenderer},
     {"^/flagged$", flaggedRenderer},
     {"^/assets/(.*)$", turbo.web.StaticFileHandler, "assets/"},
     {"^/robots.txt", turbo.web.StaticFileHandler, "assets/robots.txt"},
-}):listen(conf.port)
+}):listen(tonumber(os.getenv("TURBO_PORT")) or conf.port)
 local loop = turbo.ioloop.instance()
 loop:add_signal_handler(2, cleanup, loop)
 loop:add_signal_handler(15, cleanup, loop)

--- a/config.sample.lua
+++ b/config.sample.lua
@@ -5,6 +5,7 @@ local config = {}
 config.uri = "http://pkgs.alpinelinux.org"
 ----
 -- Turbo listening port
+-- can be overridden by setting the env var TURBO_PORT
 ----
 config.port = 8080
 ----
@@ -13,6 +14,35 @@ config.port = 8080
 config.branches = {"latest-stable", "edge"}
 config.repos = {"main", "community", "testing"}
 config.archs  = {"x86", "x86_64", "armhf"}
+----
+-- apk-tools index fields
+----
+config.index = {}
+config.index.fields = {
+	P = "name",
+	V = "version",
+	T = "description",
+	U = "url",
+	L = "license",
+	A = "arch",
+	D = "depends",
+	C = "checksum",
+	S = "size",
+	I = "installed_size",
+	p = "provides",
+	i = "install_if",
+	o = "origin",
+	m = "maintainer",
+	t = "build_time",
+	c = "commit",
+	k = "provider_priority"
+}
+----
+-- default settings
+----
+config.default = {}
+config.default.branch = "edge"
+config.default.arch = "x86_64"
 ----
 -- location of the mirror on disk
 ----
@@ -24,24 +54,27 @@ config.db = {}
 -- initialize database (create tables)
 config.db.init = false
 -- path to the sqlite db
-config.db.path = "db/aports.db"
+config.db.path = "db"
 -- multi value db fields
 config.db.fields = {"provides", "depends", "install_if"}
+-- debug. print sql queries on console
+config.db.debug = true
 ----
--- debug logging. true to enable to stdout, syslog to syslog
+-- debug logging. true to enable to stdout.
 ----
 config.logging = true
 ----
 -- google recaptcha settings
 ----
 config.rc = {}
--- set sitekey to false to disable recaptcha
--- config.rc.sitekey = ""
+config.rc.enabled = false
+config.rc.sitekey = ""
 config.rc.secret  = ""
 ----
 -- mailer settings
 ----
 config.mail = {}
+config.mail.enable = false
 config.mail.from = "Alpine Package DB <pkgs@alpinelinux.org>"
 config.mail.server = "mail.alpinelinux.org"
 config.mail.domain = "pkgs.alpinelinux.org"

--- a/controller.lua
+++ b/controller.lua
@@ -7,158 +7,178 @@ local db        = require("db")
 local mail      = require("mail")
 local model     = require("model")
 
+local cntrl     = {}
 
-local cntrl     = class("cntrl")
+db:open()
 
+-- convert bytes to human readable
+local function humanBytes(bytes)
+    local mult = 10^(2)
+    local size = { 'B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB' }
+    local factor = math.floor((string.len(bytes) -1) /3)
+    local result = bytes/math.pow(1024, factor)
+    return math.floor(result * mult + 0.5) / mult.." "..size[factor+1]
+end
 
--- move all model parts to model.lua
-function cntrl:packages(args)
+-- open the tpl file into a string and return it
+local function open_tpl(tpl)
+    local file = ("%s/%s"):format(conf.tpl, tpl)
+    local f = io.open(file, "rb")
+    local r = f:read("*all")
+    f:close()
+    return r
+end
+
+function cntrl.packages(args)
+    db:select(args.branch)
     local m = {}
     -- get packages
     local offset = (args.page - 1) * conf.pager.limit
     local pkgs = db:getPackages(args, offset)
-    m.pkgs = model:packages(pkgs)
+    m.pkgs = model.packages(pkgs, args.branch)
     local distinct = {
-        branch = db:getDistinct("packages", "branch"),
-        repo = db:getDistinct("packages", "repo"),
-        arch = db:getDistinct("packages", "arch"),
+        branch = conf.branches,
+        repo = conf.repos,
+        arch = conf.archs,
         maintainer = db:getDistinct("maintainer", "name"),
     }
     table.insert(distinct.maintainer, 1, "None")
     -- navigation bar
     m.nav = {package="active"}
     -- create form
-    m.form = model:packagesForm(args, distinct)
+    m.form = model.packagesForm(args, distinct)
     -- create pager
     local qty = db:countPackages(args)
-    local pager = self:createPager(qty, conf.pager.limit, args.page, conf.pager.offset)
-    m.pager = model:pagerModel(args, pager)
+    local pager = cntrl.createPager(qty, conf.pager.limit, args.page, conf.pager.offset)
+    m.pager = model.pagerModel(args, pager)
     -- render templates
-    m.header = lustache:render(self:tpl("header.tpl"), m)
-    m.footer = lustache:render(self:tpl("footer.tpl"), m)
-    return lustache:render(self:tpl("packages.tpl"), m)
+    m.header = lustache:render(open_tpl("header.tpl"), m)
+    m.footer = lustache:render(open_tpl("footer.tpl"), m)
+    return lustache:render(open_tpl("packages.tpl"), m)
 end
 
-function cntrl:getPackage(ops)
-    return db:getPackage(ops)
+function cntrl.getPackage(branch, repo, arch, name)
+    db:select(branch)
+    return db:getPackage(branch, repo, arch, name)
 end
 
-function cntrl:package(pkg, m)
-    local m = m or {}
+function cntrl.package(pkg, m)
+    db:select(pkg.branch)
+    m = m or {}
     -- package
-    pkg.size = self:humanBytes(pkg.size)
-    pkg.installed_size = self:humanBytes(pkg.installed_size)
-    m.pkg = model:package(pkg)
+    pkg.size = humanBytes(pkg.size)
+    pkg.installed_size = humanBytes(pkg.installed_size)
+    m.pkg = model.package(pkg)
     -- depends
     local depends = db:getDepends(pkg)
-    m.deps = model:packageRelations(depends)
+    m.deps = model.packageRelations(depends)
     m.deps_qty = #depends or 0
     -- provides
     local provides = db:getProvides(pkg)
-    m.reqbys = model:packageRelations(provides)
+    m.reqbys = model.packageRelations(provides)
     m.reqbys_qty = #provides or 0
     -- origins
     local origins = db:getOrigins(pkg)
-    m.subpkgs = model:packageRelations(origins)
+    m.subpkgs = model.packageRelations(origins)
     m.subpkgs_qty = #origins or 0
     -- navigation bar
     m.nav = {package="active"}
     -- templates
-    m.header = lustache:render(self:tpl("header.tpl"), m)
-    m.footer = lustache:render(self:tpl("footer.tpl"), m)
-    return lustache:render(self:tpl("package.tpl"), m)
+    m.header = lustache:render(open_tpl("header.tpl"), m)
+    m.footer = lustache:render(open_tpl("footer.tpl"), m)
+    return lustache:render(open_tpl("package.tpl"), m)
 end
 
 
-function cntrl:contents(args)
+function cntrl.contents(args)
+    db:select(args.branch)
     local m = {}
-    local distinct = {
-        branch = db:getDistinct("packages", "branch"),
-        repo = db:getDistinct("packages", "repo"),
-        arch = db:getDistinct("packages", "arch"),
-    }
     -- navigation menu
     m.nav = {content="active"}
     -- search form
-    m.form = model:contentsForm(args, distinct)
+    m.form = model.contentsForm(args)
     -- do not run any queries without any terms.
     if not (args.file == "" and args.path == "" and args.name == "") then
         -- get contents
         local offset = (args.page - 1) * conf.pager.limit
         local contents = db:getContents(args, offset)
-        m.contents = model:contents(contents)
+        m.contents = model.contents(contents, args.branch)
         -- pager
         local qty = db:countContents(args)
-        local pager = self:createPager(qty, conf.pager.limit, args.page, conf.pager.offset)
-        m.pager = model:pagerModel(args, pager)
+        local pager = cntrl.createPager(qty, conf.pager.limit, args.page, conf.pager.offset)
+        m.pager = model.pagerModel(args, pager)
     end
     -- render templates
-    m.header = lustache:render(self:tpl("header.tpl"), m)
-    m.footer = lustache:render(self:tpl("footer.tpl"), m)
-    return lustache:render(self:tpl("contents.tpl"), m)
+    m.header = lustache:render(open_tpl("header.tpl"), m)
+    m.footer = lustache:render(open_tpl("footer.tpl"), m)
+    return lustache:render(open_tpl("contents.tpl"), m)
 end
 
-function cntrl:flag(pkg, m)
-    if pkg and not pkg.fid then
-        local m = model:flag(pkg, m)
-        m.header = lustache:render(self:tpl("header.tpl"), m)
-        m.footer = lustache:render(self:tpl("footer.tpl"), m)
-        if pkg.branch == "edge" then
-            return lustache:render(self:tpl("flag.tpl"), m)
-        else
-            return lustache:render(self:tpl("reject_flag.tpl"), m)
-        end
+function cntrl.flag(pkg, m)
+    m = model.flag(pkg, m)
+    m.header = lustache:render(open_tpl("header.tpl"), m)
+    m.footer = lustache:render(open_tpl("footer.tpl"), m)
+    return lustache:render(open_tpl("flag.tpl"), m)
+end
+
+function cntrl.flagMail(args, pkg)
+    if conf.mail.enable == true then
+        local subject = string.format(
+            "Alpine aport %s has been flagged out of date",
+            pkg.origin
+        )
+        local m = model.flagMail(pkg, args)
+        mail:initialize(conf)
+        mail:set_to(pkg.memail)
+        mail:set_subject(subject)
+        local body = lustache:render(open_tpl("mail_body.tpl"), m)
+        mail:set_body(body)
+        return mail:send()
+    else
+        turbo.log.warning("Mail notifications are disabled.")
+        return true
     end
 end
 
-function cntrl:flagMail(args, pkg)
-    local subject = string.format(
-        "Alpine aport %s has been flagged out of date",
-        pkg.origin
-    )
-    local m = model:flagMail(pkg, args)
-    mail:initialize(conf)
-    mail:set_to(pkg.memail)
-    mail:set_subject(subject)
-    local body = lustache:render(self:tpl("mail_body.tpl"), m)
-    mail:set_body(body)
-    return mail:send()
-end
-
-function cntrl:flagged(args)
-    local m = {}
+function cntrl.flagged(args, m)
+    db:select(conf.default.branch)
+    m = m or {}
     -- get packages
     local offset = (args.page - 1) * conf.pager.limit
     local pkgs, qty = db:getFlagged(args, offset)
-    m.pkgs = model:flagged(pkgs)
-    local distinct = {
-        branch = db:getDistinct("packages", "branch"),
-        repo = db:getDistinct("packages", "repo"),
-        arch = db:getDistinct("packages", "arch"),
-        maintainer   = db:getDistinct("maintainer", "name"),
-    }
-    table.insert(distinct.maintainer, 1, "None")
+    m.pkgs = model.flagged(pkgs)
+    local maintainers = db:getDistinct("maintainer", "name")
+    table.insert(maintainers, 1, "None")
     -- create form
-    m.form = model:flaggedForm(args, distinct)
+    m.form = model.flaggedForm(args, maintainers)
     -- navigation menu
     m.nav = {flagged="active"}
     -- create pager
-    local pager = self:createPager(qty, conf.pager.limit, args.page, conf.pager.offset)
-    m.pager = model:pagerModel(args, pager)
+    local pager = cntrl.createPager(qty, conf.pager.limit, args.page, conf.pager.offset)
+    m.pager = model.pagerModel(args, pager)
     -- render templates
-    m.header = lustache:render(self:tpl("header.tpl"), m)
-    m.footer = lustache:render(self:tpl("footer.tpl"), m)
-    return lustache:render(self:tpl("flagged.tpl"), m)
+    m.header = lustache:render(open_tpl("header.tpl"), m)
+    m.footer = lustache:render(open_tpl("footer.tpl"), m)
+    return lustache:render(open_tpl("flagged.tpl"), m)
 end
 
-----
--- get non flagged package based on options
-----
-function cntrl:getNotFlagged(ops)
-    local pkg = db:getPackage(ops)
-    if pkg and not pkg.fid then
-        return pkg
-    end
+function cntrl.isFlagged(origin, repo, version)
+    db:select(conf.default.branch)
+    return db:isFlagged(origin, repo, version)
+end
+
+function cntrl.isOrigin(branch, repo, origin, version)
+    db:select(branch)
+    return db:isOrigin(repo, origin, version)
+end
+
+function cntrl.getMaintainer(branch, origin)
+    db:select(branch)
+    return db:getMaintainer(origin)
+end
+
+function cntrl.flagOrigin(args, pkg)
+    return db:flagOrigin(args, pkg)
 end
 
 -- create a array with pager page numbers
@@ -166,7 +186,7 @@ end
 -- (limit) results per page/query
 -- (current) the current page
 -- (offset) the left and right offset from current page
-function cntrl:createPager(total, limit, current, offset)
+function cntrl.createPager(total, limit, current, offset)
     local r = {}
     local pages = math.ceil(total/limit)
     local pagers = math.min(offset*2+1, pages)
@@ -186,7 +206,7 @@ end
 ----
 -- verify recaptch responce
 ----
-function cntrl:verifyRecaptcha(response)
+function cntrl.verifyRecaptcha(response)
     local uri = "https://www.google.com/recaptcha/api/siteverify"
     local kwargs = {}
     kwargs.method = "POST"
@@ -202,22 +222,8 @@ function cntrl:verifyRecaptcha(response)
     return result.success
 end
 
--- convert bytes to human readable
-function cntrl:humanBytes(bytes)
-    local mult = 10^(2)
-    local size = { 'B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB' }
-    local factor = math.floor((string.len(bytes) -1) /3)
-    local result = bytes/math.pow(1024, factor)
-    return math.floor(result * mult + 0.5) / mult.." "..size[factor+1]
-end
-
--- read the tpl file into a string and return it
-function cntrl:tpl(tpl)
-    local tpl = string.format("%s/%s", conf.tpl, tpl)
-    local f = io.open(tpl, "rb")
-    local r = f:read("*all")
-    f:close()
-    return r
+function cntrl.cleanup()
+    db:close()
 end
 
 return cntrl

--- a/mail.lua
+++ b/mail.lua
@@ -8,7 +8,7 @@ local format_email_addr = utils.format_email_addr
 --
 -- mail class using lua socket
 --
-local mail = class("mail")
+local mail = {}
 
 function mail:initialize(conf)
     self.server = conf.mail.server

--- a/model.lua
+++ b/model.lua
@@ -3,62 +3,30 @@ local utils      = require('utils')
 
 local default    = utils.default
 local escape_uri = utils.escape_uri
-local model      = class('model')
 
-
--- keys used in alpine linux repository index
-function model:indexFormat(k)
-    local f = {
-        P = "name",
-        V = "version",
-        T = "description",
-        U = "url",
-        L = "license",
-        A = "arch",
-        D = "depends",
-        C = "checksum",
-        S = "size",
-        I = "installed_size",
-        p = "provides",
-        i = "install_if",
-        o = "origin",
-        m = "maintainer",
-        t = "build_time",
-        c = "commit",
-    }
-    return k and f[k] or f
-end
-
--- package format as stored in database
-function model:packageFormat(k)
-    local f = self:indexFormat()
-    f.r = "repo"
-    f.b = "branch"
-    return k and f[k] or f
-end
+local model      = {}
 
 -- convert release name to branch name
-function model:branchFormat(branch)
+function model.branchFormat(branch)
     return (branch == "edge") and "master" or string.format("%s-stable", branch:sub(2))
 end
 
 -- convert branch name to one used in logfiles
-function model:logBranchFormat(branch)
+function model.logBranchFormat(branch)
     return branch:sub(1,1)=="v" and string.gsub(branch:sub(2),"%.","-") or branch
 end
 
--- what happends here with version?
-function model:packages(pkgs)
+function model.packages(pkgs, branch)
     local r = {}
     for k,v in pairs(pkgs) do
         r[k] = {}
         r[k].name = {
-            path=string.format("/package/%s/%s/%s/%s", v.branch, v.repo, v.arch, v.name),
+            path=string.format("/package/%s/%s/%s/%s", branch, v.repo, v.arch, v.name),
             text=v.name,
             title=v.description
         }
         r[k].version = {
-            path=string.format("/flag/%s/%s/%s/%s", v.branch, v.repo, v.origin, v.version),
+            path=string.format("/flag/%s/%s/%s", v.repo, v.origin, v.version),
             text=v.version,
             title="Flag this package out of date"
         }
@@ -68,27 +36,28 @@ function model:packages(pkgs)
             title=v.url
         }
         r[k].license = v.license
-        r[k].branch = v.branch
+        r[k].branch = branch
         r[k].arch = v.arch
         r[k].repo = v.repo
         r[k].maintainer = v.mname or "None"
         r[k].build_time = v.build_time
-        if (v.fid) then r[k].flagged = {date=v.flagged} end
+        if (v.flagged) then r[k].flagged = {date=v.flagged} end
+        if branch == conf.default.branch then r[k].default = true end
     end
     return r
 end
 
-function model:packagesForm(args, distinct)
+function model.packagesForm(args, distinct)
     local m = {}
     m.name = args.name
-    m.branch = self:FormSelect(distinct.branch, args.branch)
-    m.repo = self:FormSelect(distinct.repo, args.repo)
-    m.arch = self:FormSelect(distinct.arch, args.arch)
-    m.maintainer = self:FormSelect(distinct.maintainer, args.maintainer)
+    m.branch = model.FormSelect({unpack(conf.branches)}, args.branch)
+    m.repo = model.FormSelect({unpack(conf.repos)}, args.repo)
+    m.arch = model.FormSelect({unpack(conf.archs)}, args.arch)
+    m.maintainer = model.FormSelect(distinct.maintainer, args.maintainer)
     return m
 end
 
-function model:FormSelect(options, selected)
+function model.FormSelect(options, selected)
     local r = {}
     table.insert(options, 1, "")
     for k,v in pairs(options) do
@@ -98,26 +67,32 @@ function model:FormSelect(options, selected)
     return r
 end
 
-function model:package(pkg)
+function model.package(pkg)
     local r = {}
     -- populate default values or None if not set.
-    for _,v in pairs(self:packageFormat()) do
+    for _,v in pairs(conf.index.fields) do
         r[v] = default(pkg[v], "None")
     end
+    r.branch = pkg.branch
+    r.repo = pkg.repo
+
     r.nav = {package="active"}
     r.version = {text=pkg.version}
-    if pkg.fid then
+    if (pkg.branch == conf.default.branch) then r.flaggable = true end
+    if pkg.flagged then
         r.version.class = "text-danger"
         r.version.title = string.format("Flagged: %s", pkg.flagged)
         r.version.path = "#"
     else
         r.version.class = "text-success"
         r.version.title = string.format("Flag this package out of date")
-        r.version.path = string.format("/flag/%s/%s/%s/%s",pkg.branch, pkg.repo, pkg.origin, pkg.version)
+        r.version.path = string.format("/flag/%s/%s/%s",
+            pkg.repo, pkg.origin, pkg.version)
     end
     r.maintainer = pkg.mname or "None"
     r.origin = {
-        path=string.format("/package/%s/%s/%s/%s", pkg.branch, pkg.repo, pkg.arch, pkg.origin),
+        path=string.format("/package/%s/%s/%s/%s",
+            pkg.branch, pkg.repo, pkg.arch, pkg.origin),
         text=pkg.origin
     }
     r.commit = {
@@ -125,29 +100,29 @@ function model:package(pkg)
         text=pkg.commit
     }
     r.contents = {
-        path=string.format("/contents?branch=%s&name=%s&arch=%s&repo=%s", pkg.branch, pkg.name, pkg.arch, pkg.repo),
+        path=string.format("/contents?branch=%s&name=%s&arch=%s&repo=%s",
+            pkg.branch, pkg.name, pkg.arch, pkg.repo),
         text="Contents of package"
     }
     r.git = string.format(conf.git.pkgpath, pkg.repo, pkg.origin,
-        self:branchFormat(pkg.branch))
-    r.log = string.format(conf.buildlog, self:logBranchFormat(pkg.branch),
+        model.branchFormat(pkg.branch))
+    r.log = string.format(conf.buildlog, model.logBranchFormat(pkg.branch),
         pkg.arch, pkg.repo, pkg.name, pkg.name, pkg.version)
     return r
 end
 
-function model:flagged(pkgs)
+function model.flagged(pkgs)
     local r = {}
     for k,v in pairs(pkgs) do
         r[k] = {}
         r[k].origin = {
-            --path=string.format("/package/%s/%s/%s", v.branch, v.repo, v.origin),
-            path=string.format("packages?branch=%s&repo=%s&name=%s", v.branch, v.repo, v.origin),
+            path = ("packages?branch=%s&repo=%s&name=%s"):format(
+                conf.default.branch, v.repo, v.origin),
             text=v.origin,
             title=v.description
         }
         r[k].version = v.version
         r[k].new_version = v.new_version
-        r[k].branch = v.branch
         r[k].arch = v.arch
         r[k].repo = v.repo
         r[k].maintainer = v.mname or "None"
@@ -157,17 +132,15 @@ function model:flagged(pkgs)
     return r
 end
 
-function model:flaggedForm(args, distinct)
+function model.flaggedForm(args, maintainers)
     local m = {}
     m.origin = args.origin
-    m.branch = model:FormSelect(distinct.branch, args.branch)
-    m.repo = model:FormSelect(distinct.repo, args.repo)
-    m.arch = model:FormSelect(distinct.arch, args.arch)
-    m.maintainer = model:FormSelect(distinct.maintainer, args.maintainer)
+    m.repo = model.FormSelect({unpack(conf.repos)}, args.repo)
+    m.maintainer = model.FormSelect(maintainers, args.maintainer)
     return m
 end
 
-function model:packageRelations(pkgs)
+function model.packageRelations(pkgs)
     local r = {}
     for _,v in pairs(pkgs) do
         local path = string.format("/package/%s/%s/%s/%s", v.branch, v.repo, v.arch, v.name)
@@ -176,7 +149,7 @@ function model:packageRelations(pkgs)
     return r
 end
 
-function model:pagerModel(args, pager)
+function model.pagerModel(args, pager)
     local result = {}
     if pager.last > 1 then
         table.insert(pager, 1, "&laquo;")
@@ -205,45 +178,44 @@ function model:pagerModel(args, pager)
     return result
 end
 
-function model:contents(cnt)
+function model.contents(cnt, branch)
     local r = {}
     for k,v in pairs(cnt) do
         r[k] = {}
-        r[k].branch = v.branch
+        r[k].branch = branch
         r[k].repo = v.repo
         r[k].arch = v.arch
         r[k].file = string.format("%s/%s", v.path, v.file)
         r[k].pkgname = {}
-        r[k].pkgname.path = string.format("/package/%s/%s/%s/%s", v.branch, v.repo, v.arch, v.name)
+        r[k].pkgname.path = string.format("/package/%s/%s/%s/%s", branch, v.repo, v.arch, v.name)
         r[k].pkgname.text = v.name
     end
     return r
 end
 
-function model:contentsForm(args, distinct)
+function model.contentsForm(args)
     local m = {}
     m.file = args.file
     m.path = args.path
     m.name = args.name
-    m.branch = self:FormSelect(distinct.branch, args.branch)
-    m.repo = self:FormSelect(distinct.repo, args.repo)
-    m.arch = self:FormSelect(distinct.arch, args.arch)
+    m.branch = model.FormSelect({unpack(conf.branches)}, args.branch)
+    m.repo = model.FormSelect({unpack(conf.repos)}, args.repo)
+    m.arch = model.FormSelect({unpack(conf.archs)}, args.arch)
     return m
 end
 
-function model:flag(pkg, m)
+function model.flag(pkg, m)
     m = m or {}
     m.form = m.form or {}
     m.nav = {flagged="active"}
     m.repo = pkg.repo
     m.origin = pkg.origin
     m.version = pkg.version
-    m.maintainer = pkg.mname or "None"
     m.sitekey = conf.rc.sitekey
     return m
 end
 
-function model:flagMail(pkg, args)
+function model.flagMail(pkg, args)
     return {
         maintainer = pkg.mname,
         origin = pkg.origin,
@@ -253,4 +225,4 @@ function model:flagMail(pkg, args)
     }
 end
 
-return model()
+return model

--- a/tools/anitya-check-all.lua
+++ b/tools/anitya-check-all.lua
@@ -52,7 +52,7 @@ end
 
 log.notice 'Checking outdated packages using Anitya...'
 
-cc.foreach(aports.each_aport_name('edge'), function(pkgname)
+cc.foreach(aports.each_aport_name(), function(pkgname)
     local proj = fetch_distro_pkg(pkgname)
 
     if proj and proj.version then

--- a/tools/anitya-watch.lua
+++ b/tools/anitya-watch.lua
@@ -98,13 +98,13 @@ end
 
 local poller = zpoller.new(1)
 poller:add(sock, zmq.POLLIN, function()
-    local payload, err = receive_json_msg(sock)
-    if err then
+    local payload, err2 = receive_json_msg(sock)
+    if err2 then
         log.error('Failed to receive message from fedmsg: '..err)
     end
-    local ok, err = pcall(handlers[payload.topic], payload.msg)
+    local ok, err3 = pcall(handlers[payload.topic], payload.msg)
     if not ok then
-        log.error(err)
+        log.error(err3)
     end
 end)
 

--- a/tools/import.lua
+++ b/tools/import.lua
@@ -1,172 +1,155 @@
+#!/usr/bin/env luajit
+
 local sqlite    = require("lsqlite3")
-local turbo     = require("turbo")
 
 local conf      = require("config")
-local cntrl     = require("controller")
 local utils     = require("utils")
 
----
--- import
----
+local db
 
-local import    = class("import")
-
-function import:initialize()
-    self.db = sqlite.open(conf.db.path)
-    self.db:exec("PRAGMA foreign_keys=ON")
-    self.db:exec("PRAGMA journal_mode=WAL")
-    if conf.db.init then self:createTables() end
-end
-
-function import:finalize()
-    self.db:close()
-end
-
-function import:split(d,s)
-    local r = {}
-    for i in s:gmatch(d) do table.insert(r,i) end
-    return r
-end
-
-function import:log(msg)
+local function log(msg)
     if conf.logging then
-        if conf.logging == "syslog" then
-            os.execute("logger "..msg)
-        else
-            print(msg)
-        end
+        print(msg)
     end
 end
 
-function import:fileExists(path)
-    local f = io.open(path, "r")
-    if f ~= nil then
-        io.close(f)
-        return true
+local function sql_debug(fname, sql)
+    if conf.db.debug == true then
+        print(("Function: %s \nDatabase error: %s \nSQL Query:\n%s"):format(
+            fname, db:errmsg(), sql))
     end
-    return false
 end
 
--- keys used in alpine linux repository index
-function import:indexFormat(k)
-    local f = {
-        P = "name",
-        V = "version",
-        T = "description",
-        U = "url",
-        L = "license",
-        A = "arch",
-        D = "depends",
-        C = "checksum",
-        S = "size",
-        I = "installed_size",
-        p = "provides",
-        i = "install_if",
-        o = "origin",
-        m = "maintainer",
-        t = "build_time",
-        c = "commit",
-    }
-    return k and f[k] or f
-end
-
-function import:createTables()
-    self.db:exec( [[ CREATE TABLE IF NOT EXISTS 'packages' (
-        'id' INTEGER primary key,
-        'name' TEXT,
-        'version' TEXT,
-        'description' TEXT,
-        'url' TEXT,
-        'license' TEXT,
-        'arch' TEXT,
-        'branch' TEXT,
-        'repo' TEXT,
-        'checksum' TEXT,
-        'size' INTEGER,
-        'installed_size' INTEGER,
-        'origin' TEXT,
-        'maintainer' INTEGER,
-        'build_time' INTEGER,
-        'commit' TEXT,
-        'fid' INTEGER
-    ) ]])
-    self.db:exec([[ CREATE INDEX IF NOT EXISTS 'packages_name' on 'packages' (name) ]])
-    self.db:exec([[ CREATE INDEX IF NOT EXISTS 'packages_maintainer' on 'packages' (maintainer) ]])
-    self.db:exec([[ CREATE INDEX IF NOT EXISTS 'packages_build_time' on 'packages' (build_time) ]])
-    self.db:exec([[ CREATE INDEX IF NOT EXISTS 'packages_origin' on 'packages' (origin) ]])
-    self.db:exec([[ CREATE TABLE IF NOT EXISTS 'files' (
-        'id' INTEGER primary key,
-        'file' TEXT,
-        'path' TEXT,
-        'pkgname' TEXT,
-        'pid' INTEGER REFERENCES packages(id) ON DELETE CASCADE
-    ) ]])
-    self.db:exec([[ CREATE INDEX IF NOT EXISTS 'files_file' on 'files' (file) ]])
-    self.db:exec([[ CREATE INDEX IF NOT EXISTS 'files_path' on 'files' (path) ]])
-    self.db:exec([[ CREATE INDEX IF NOT EXISTS 'files_pkgname' on 'files' (pkgname) ]])
-    self.db:exec([[ CREATE INDEX IF NOT EXISTS 'files_pid' on 'files' (pid) ]])
-    local field = [[ CREATE TABLE IF NOT EXISTS '%s' (
-        'name' TEXT,
-        'version' TEXT,
-        'operator' TEXT,
-        'pid' INTEGER REFERENCES packages(id) ON DELETE CASCADE
-    )]]
+local function create_tables()
+    if conf.db.init ~= true then return true end
+    -- packages
+    db:exec([[
+        CREATE TABLE IF NOT EXISTS 'packages' (
+            'id' INTEGER PRIMARY KEY,
+            'name' TEXT,
+            'version' TEXT,
+            'description' TEXT,
+            'url' TEXT,
+            'license' TEXT,
+            'arch' TEXT,
+            'repo' TEXT,
+            'checksum' TEXT,
+            'size' INTEGER,
+            'installed_size' INTEGER,
+            'origin' TEXT,
+            'maintainer' INTEGER,
+            'build_time' INTEGER,
+            'commit' TEXT,
+            'provider_priority' INTEGER,
+            'fid' INTEGER
+        )
+    ]])
+    db:exec([[ CREATE INDEX IF NOT EXISTS 'packages_name' on 'packages' (name) ]])
+    db:exec([[ CREATE INDEX IF NOT EXISTS 'packages_maintainer' on 'packages' (maintainer) ]])
+    db:exec([[ CREATE INDEX IF NOT EXISTS 'packages_build_time' on 'packages' (build_time) ]])
+    db:exec([[ CREATE INDEX IF NOT EXISTS 'packages_origin' on 'packages' (origin) ]])
+    -- files
+    db:exec([[
+        CREATE TABLE IF NOT EXISTS 'files' (
+            'id' INTEGER PRIMARY KEY,
+            'file' TEXT,
+            'path' TEXT,
+            'pid' INTEGER REFERENCES packages(id) ON DELETE CASCADE
+        )
+    ]])
+    db:exec([[ CREATE INDEX IF NOT EXISTS 'files_file' on 'files' (file) ]])
+    db:exec([[ CREATE INDEX IF NOT EXISTS 'files_path' on 'files' (path) ]])
+    db:exec([[ CREATE INDEX IF NOT EXISTS 'files_pid' on 'files' (pid) ]])
+    -- provides, depends, install_if
+    local field = [[
+        CREATE TABLE IF NOT EXISTS '%s' (
+            'name' TEXT,
+            'version' TEXT,
+            'operator' TEXT,
+            'pid' INTEGER REFERENCES packages(id) ON DELETE CASCADE
+        )
+    ]]
     for _,v in pairs(conf.db.fields) do
-        self.db:exec(string.format(field,v))
-        self.db:exec(string.format([[CREATE INDEX IF NOT EXISTS '%s_name' on '%s' (name)]], v, v))
-        self.db:exec(string.format([[CREATE INDEX IF NOT EXISTS '%s_pid' on '%s' (pid)]], v, v))
+        db:exec((field):format(v))
+        db:exec(([[CREATE INDEX IF NOT EXISTS '%s_name' on %q (name)]]):format(v, v))
+        db:exec(([[CREATE INDEX IF NOT EXISTS '%s_pid' on %q (pid)]]):format(v, v))
     end
-    self.db:exec([[CREATE TABLE IF NOT EXISTS maintainer (
-        'id' INTEGER primary key,
-        'name' TEXT,
-        'email' TEXT
-    )]])
-    self.db:exec([[CREATE INDEX IF NOT EXISTS 'maintainer_name'
-        on maintainer (name)]])
-    self.db:exec([[ CREATE TABLE IF NOT EXISTS 'repoversion' (
-        'branch' TEXT,
-        'repo' TEXT,
-        'arch' TEXT,
-        'version' TEXT
-    )]])
-    self.db:exec([[CREATE UNIQUE INDEX IF NOT EXISTS 'repoversion_version'
-        on repoversion (branch, repo, arch)]])
-    self.db:exec([[ CREATE TABLE IF NOT EXISTS 'flagged' (
-        'fid' INTEGER primary key,
-        'created' INTEGER,
-        'reporter' TEXT,
-        'new_version' TEXT,
-        'message' TEXT
-    ) ]])
+    -- maintainers
+    db:exec([[
+        CREATE TABLE IF NOT EXISTS maintainer (
+            'id' INTEGER PRIMARY KEY,
+            'name' TEXT,
+            'email' TEXT
+        )
+    ]])
+    db:exec([[CREATE INDEX IF NOT EXISTS 'maintainer_name' on maintainer (name) ]])
+    -- repoversion
+    db:exec([[
+        CREATE TABLE IF NOT EXISTS 'repoversion' (
+            'repo' TEXT,
+            'arch' TEXT,
+            'version' TEXT,
+            PRIMARY KEY ('repo', 'arch')
+        ) WITHOUT ROWID
+    ]])
+end
+
+local function create_flagged_table()
+    if conf.db.init ~= true then return true end
+    db:exec([[
+        CREATE TABLE IF NOT EXISTS 'flagged.flagged' (
+            'origin' TEXT,
+            'version' TEXT,
+            'repo' TEXT,
+            'created' INTEGER,
+            'updated' INTEGER,
+            'reporter' TEXT,
+            'new_version' TEXT,
+            'message' TEXT,
+            PRIMARY KEY ('origin', 'version', 'repo')
+        ) WITHOUT ROWID
+    ]])
 end
 
 ---
 -- get the current git describe from DESCRIPTION file
 ---
-function import:getRepoVersion(branch, repo, arch)
-    local index = string.format("%s/%s/%s/%s/APKINDEX.tar.gz",
-        conf.mirror, branch, repo, arch)
-    local f = io.popen(string.format("tar -Ozx -f '%s' DESCRIPTION", index))
+local function get_repo_version(branch, repo, arch)
+    local res = {}
+    local index = ("%s/%s/%s/%s/APKINDEX.tar.gz"):format(conf.mirror, branch, repo, arch)
+    local f = io.popen(("tar -Ozx -f '%s' DESCRIPTION"):format(index))
     for line in f:lines() do
-        return line
+        table.insert(res, line)
     end
+    f:close()
+    if next(res) then return res[1] end
 end
 
-function import:getLocalRepoVersion(branch, repo, arch)
-    local sql = [[ select version from repoversion
-        where branch = ? and repo = ? and arch = ? ]]
-    local stmt = self.db:prepare(sql)
-    stmt:bind_values(branch, repo, arch)
+local function get_local_repo_version(repo, arch)
+    local sql = [[
+        SELECT version
+        FROM repoversion
+        WHERE repo = ?
+        AND arch = ?
+    ]]
+    local stmt = db:prepare(sql)
+    stmt:bind_values(repo, arch)
     local r = (stmt:step() == sqlite.ROW) and stmt:get_value(0) or false
     stmt:finalize()
     return r
 end
 
-function import:updateLocalRepoVersion(branch, repo, arch, version)
-    local sql = [[ insert or replace into repoversion ('version', 'branch', 'repo', 'arch')
-        VALUES (:version, :branch, :repo, :arch) ]]
-    local stmt = self.db:prepare(sql)
-    stmt:bind_names({version=version,branch=branch,repo=repo,arch=arch})
+local function update_local_repo_version(repo, arch, version)
+    local sql = [[
+        INSERT OR REPLACE INTO repoversion (
+            'version', 'repo', 'arch'
+        )
+        VALUES (
+            :version, :repo, :arch
+        )
+    ]]
+    local stmt = db:prepare(sql)
+    stmt:bind_values(version, repo, arch)
     stmt:step()
     stmt:finalize()
 end
@@ -174,24 +157,25 @@ end
 ---
 -- compare remote repo version with local and return remote version if updated
 ---
-function import:repoUpdated(branch, repo, arch)
-    local v = self:getRepoVersion(branch, repo, arch)
-    local l = self:getLocalRepoVersion(branch, repo, arch)
+local function repo_updated(branch, repo, arch)
+    local v = get_repo_version(branch, repo, arch)
+    local l = get_local_repo_version(repo, arch)
     if (v ~= l) then return v end
 end
 
-function import:getApkIndex(branch, repo, arch)
+local function get_apk_index(branch, repo, arch)
     local r,i = {},{}
-    local index = string.format("%s/%s/%s/%s/APKINDEX.tar.gz",
-        conf.mirror, branch, repo, arch)
-    local f = io.popen(string.format("tar -Ozx -f '%s' APKINDEX", index))
+    local index = ("%s/%s/%s/%s/APKINDEX.tar.gz"):format(conf.mirror, branch, repo, arch)
+    local f = io.popen(("tar -Ozx -f %q APKINDEX"):format(index))
     for line in f:lines() do
         if (line ~= "") then
             local k,v = line:match("^(%a):(.*)")
-            local key = self:indexFormat(k)
-            r[key] = k:match("^[Dpi]$") and self:split("%S+", v) or v
+            local key = conf.index.fields[k]
+            if key then
+                r[key] = k:match("^[Dpi]$") and utils.split(v, "%S+") or v
+            end
         else
-            local nv = string.format("%s-%s", r.name, r.version)
+            local nv = ("%s-%s"):format(r.name, r.version)
             r.repo = repo
             r.branch = branch
             i[nv] = r
@@ -202,18 +186,20 @@ function import:getApkIndex(branch, repo, arch)
     return i
 end
 
-function import:getChanges(branch, repo, arch)
+local function get_changes(branch, repo, arch)
     local del = {}
-    local add = self:getApkIndex(branch, repo, arch)
-    local sql = [[SELECT branch, repo, arch, name,version FROM 'packages'
-        WHERE branch = ?
-        AND repo = ?
-        AND arch = ?
+    local add = get_apk_index(branch, repo, arch)
+    local sql = [[
+        SELECT repo, arch, name, version, origin
+        FROM packages
+        WHERE repo = :repo
+        AND arch = :arch
     ]]
-    local stmt = self.db:prepare(sql)
-    stmt:bind_values(branch,repo,arch)
+    local stmt = db:prepare(sql)
+    sql_debug("get_changes", sql)
+    stmt:bind_values(repo, arch)
     for r in stmt:nrows() do
-        local nv = string.format("%s-%s", r.name, r.version)
+        local nv = ("%s-%s"):format(r.name, r.version)
         if add[nv] then
             add[nv] = nil
         else
@@ -224,37 +210,7 @@ function import:getChanges(branch, repo, arch)
     return add,del
 end
 
-function import:addPackages(branch, add)
-    for _,pkg in pairs(add) do
-        local apk = string.format("%s/%s/%s/%s/%s-%s.apk",
-            conf.mirror, branch, pkg.repo, pkg.arch, pkg.name, pkg.version)
-        if self:fileExists(apk) then
-            self:log(string.format("Adding: %s/%s/%s/%s-%s", branch, pkg.repo, pkg.arch, pkg.name, pkg.version))
-            pkg.maintainer = self:addMaintainer(pkg.maintainer)
-            local pid = self:addHeader(pkg)
-            self:addFields(pid, pkg)
-            self:addFiles(pid, apk, pkg)
-        else
-            self:log(string.format("Could not find pkg: %s/%s/%s/%s-%s", branch, pkg.repo, pkg.arch, pkg.name, pkg.version))
-        end
-    end
-end
-
-function import:addHeader(pkg)
-    local sql = [[ insert into 'packages' ("name", "version", "description", "url",
-        "license", "arch", "branch", "repo", "checksum", "size", "installed_size", "origin",
-        "maintainer", "build_time", "commit") values(:name, :version, :description,
-        :url, :license, :arch, :branch, :repo, :checksum, :size, :installed_size, :origin,
-        :maintainer, :build_time, :commit)]]
-    local stmt = self.db:prepare(string.format(sql))
-    stmt:bind_names(pkg)
-    stmt:step()
-    local pid = stmt:last_insert_rowid()
-    stmt:finalize()
-    return pid
-end
-
-function import:formatMaintainer(maintainer)
+local function format_maintainer(maintainer)
     if maintainer then
         local name, email = utils.parse_email_addr(maintainer)
         if email then
@@ -263,13 +219,19 @@ function import:formatMaintainer(maintainer)
     end
 end
 
-function import:addMaintainer(maintainer)
-    local m = self:formatMaintainer(maintainer)
+local function add_maintainer(maintainer)
+    local m = format_maintainer(maintainer)
     if m then
-        local sql = [[ insert or replace into maintainer ('id', 'name', 'email')
-            VALUES ((SELECT id FROM maintainer WHERE name = :name AND email = :email),
-            :name, :email) ]]
-        local stmt = self.db:prepare(sql)
+        local sql = [[
+            INSERT OR REPLACE INTO maintainer ('id', 'name', 'email')
+            VALUES (
+                (SELECT id FROM maintainer WHERE name = :name AND email = :email),
+                :name,
+                :email
+            )
+        ]]
+        local stmt = db:prepare(sql)
+        sql_debug("add_maintainer", sql)
         stmt:bind_names(m)
         stmt:step()
         local r = stmt:last_insert_rowid()
@@ -279,30 +241,29 @@ function import:addMaintainer(maintainer)
     end
 end
 
---- Removes maintainers that don't maintain any package.
-function import:cleanMaintainers()
-    local sql = [[ delete from 'maintainer'
-        where id not in (select maintainer from 'packages') ]]
-    local stmt = self.db:prepare(sql)
+local function add_header(pkg)
+    local sql = [[
+        INSERT INTO 'packages' (
+            "name", "version", "description", "url", "license", "arch", "repo",
+            "checksum", "size", "installed_size", "origin", "maintainer",
+            "build_time", "commit", "provider_priority"
+        )
+        VALUES (
+            :name, :version, :description, :url, :license, :arch, :repo,
+            :checksum, :size, :installed_size, :origin, :maintainer,
+            :build_time, :commit, :provider_priority
+        )
+    ]]
+    local stmt = db:prepare(sql)
+    sql_debug("add_header", sql)
+    stmt:bind_names(pkg)
     stmt:step()
+    local pid = stmt:last_insert_rowid()
     stmt:finalize()
+    return pid
 end
 
-function import:delPackages(branch, del)
-    local sql = [[ delete FROM 'packages' WHERE "branch" = :branch
-        AND "repo" = :repo AND "arch" = :arch AND "name" = :name
-        AND "version" = :version ]]
-    local stmt = self.db:prepare(sql)
-    for _,pkg in pairs(del) do
-        self:log(string.format("Deleting: %s/%s/%s/%s-%s", branch, pkg.repo, pkg.arch, pkg.name, pkg.version))
-        stmt:bind_names(pkg)
-        stmt:step()
-        stmt:reset()
-    end
-    stmt:finalize()
-end
-
-function import:formatField(v)
+local function format_field(v)
     local r = {}
     for _,o in ipairs({">=","<=","><","=",">","<"}) do
         if v:match(o) then
@@ -315,16 +276,22 @@ function import:formatField(v)
     return r
 end
 
-function import:addFields(pid, pkg)
+local function add_fields(pid, pkg)
     for _,field in ipairs(conf.db.fields) do
         local values = pkg[field] or {}
         --insert pkg name as a provides in the table.
         if field == "provides" then table.insert(values, pkg.name) end
-        local sql = [[ insert into '%s' ("pid", "name", "version", "operator")
-            VALUES (:pid, :name, :version, :operator) ]]
-        local stmt = self.db:prepare(string.format(sql, field))
+        local sql = [[
+            INSERT INTO '%s' (
+                "pid", "name", "version", "operator"
+            )
+            VALUES (
+                :pid, :name, :version, :operator
+            )
+        ]]
+        local stmt = db:prepare((sql):format(field))
         for _,v in pairs(values) do
-            local r = self:formatField(v)
+            local r = format_field(v)
             r.pid = pid
             stmt:bind_names(r)
             stmt:step()
@@ -334,12 +301,22 @@ function import:addFields(pid, pkg)
     end
 end
 
-function import:getFilelist(apk)
+local function format_file(line)
+    local path, file
+    if line:match("/") then
+        path, file = line:match("(.*/)(.*)")
+        if path:match("/$") then path = path:sub(1, -2) end
+        return "/"..path,file
+    end
+    return "/", line
+end
+
+local function get_file_list(apk)
     local r = {}
-    local f = io.popen(string.format("tar ztf '%s'", apk))
+    local f = io.popen(("tar ztf %q"):format(apk))
     for line in f:lines() do
         if not (line:match("^%.") or line:match("/$")) then
-            local path,file = self:formatFile(line)
+            local path,file = format_file(line)
             table.insert(r, {path=path,file=file})
         end
     end
@@ -347,11 +324,18 @@ function import:getFilelist(apk)
     return r
 end
 
-function import:addFiles(pid, apk, pkg)
-    local files = self:getFilelist(apk)
-    local sql = [[ insert into 'files' ("file", "path", "pkgname", "pid")
-        VALUES (:file, :path, :pkgname, :pid) ]]
-    local stmt = self.db:prepare(sql)
+local function add_files(pid, apk, pkg)
+    local files = get_file_list(apk)
+    local sql = [[
+        INSERT INTO 'files' (
+            "file", "path", "pid"
+        )
+        VALUES (
+            :file, :path, :pid
+        )
+    ]]
+    local stmt = db:prepare(sql)
+    sql_debug("add_files", sql)
     for _,file in pairs(files) do
         file.pkgname = pkg.name
         file.pid = pid
@@ -362,42 +346,124 @@ function import:addFiles(pid, apk, pkg)
     stmt:finalize()
 end
 
-function import:formatFile(line)
-    local path, file
-    if line:match("/") then
-        path, file = line:match("(.*/)(.*)")
-        if path:match("/$") then path = path:sub(1, -2) end
-        return "/"..path,file
+local function add_packages(branch, add)
+    for _,pkg in pairs(add) do
+        local apk = ("%s/%s/%s/%s/%s-%s.apk"):format(conf.mirror, branch,
+            pkg.repo, pkg.arch, pkg.name, pkg.version)
+        if utils.file_exists(apk) then
+            log(("Adding: %s/%s/%s/%s-%s"):format(branch, pkg.repo, pkg.arch,
+                pkg.name, pkg.version))
+            pkg.maintainer = add_maintainer(pkg.maintainer)
+            local pid = add_header(pkg)
+            add_fields(pid, pkg)
+            add_files(pid, apk, pkg)
+        else
+            log(("Could not find pkg: %s/%s/%s/%s-%s"):format(branch, pkg.repo,
+                pkg.arch, pkg.name, pkg.version))
+        end
     end
-    return "/", line
 end
 
-function import:run()
-    for _,branch in pairs(conf.branches) do
-        for _,repo in pairs(conf.repos) do
-            for _,arch in pairs(conf.archs) do
-                local index = string.format("%s/%s/%s/%s/APKINDEX.tar.gz",
-                    conf.mirror, branch, repo, arch)
-                if self:fileExists(index) then
-                    local version = self:repoUpdated(branch, repo, arch)
-                    if version then
-                        self:log(string.format("Updating: %s/%s/%s",branch, repo, arch))
-                        local add,del = self:getChanges(branch, repo, arch)
-                        self.db:exec("begin transaction")
-                        self:addPackages(branch, add)
-                        self:delPackages(branch, del)
-                        self:cleanMaintainers()
-                        self.db:exec("commit")
-                        self:updateLocalRepoVersion(branch, repo, arch, version)
-                        cntrl:clearCache()
-                    end
+--- Removes maintainers that don't maintain any package.
+local function clean_maintainers()
+    local sql = [[
+        DELETE FROM 'maintainer'
+        WHERE id NOT IN (SELECT maintainer FROM 'packages')
+    ]]
+    local stmt = db:prepare(sql)
+    sql_debug("clean_maintainers", sql)
+    stmt:step()
+    stmt:finalize()
+end
+
+local function del_packages(branch, del)
+    local sql = [[
+        DELETE FROM 'packages'
+        WHERE "repo" = :repo
+        AND "arch" = :arch
+        AND "name" = :name
+        AND "version" = :version
+    ]]
+    local stmt = db:prepare(sql)
+    sql_debug("del_packages", sql)
+    for _,pkg in pairs(del) do
+        log(("Deleting: %s/%s/%s/%s-%s"):format(branch, pkg.repo, pkg.arch,
+            pkg.name, pkg.version))
+        stmt:bind_names(pkg)
+        stmt:step()
+        stmt:reset()
+    end
+    stmt:finalize()
+end
+
+local function update_flagged(unflag)
+    local sql = [[
+        UPDATE flagged SET updated = strftime('%s', 'now')
+        WHERE repo = :repo
+        AND origin = :origin
+        AND version = :version
+    ]]
+    local stmt = db:prepare(sql)
+    sql_debug("update_flagged", sql)
+    for _,v in pairs(unflag) do
+        stmt:bind_names(v)
+        stmt:step()
+        stmt:reset()
+        if db:changes() > 0 then
+            log(("Unflagging: %s/%s/%s"):format(v.repo, v.origin, v.version))
+        end
+    end
+    stmt:finalize()
+end
+
+local function update(branch, repo, arch)
+    local index = ("%s/%s/%s/%s/APKINDEX.tar.gz"):format(conf.mirror, branch, repo, arch)
+    local res = {}
+    if utils.file_exists(index) then
+        local version = repo_updated(branch, repo, arch)
+        if version then
+            log(("Updating: %s/%s/%s"):format(branch, repo, arch))
+            local add,del = get_changes(branch, repo, arch)
+            add_packages(branch, add)
+            del_packages(branch, del)
+            clean_maintainers()
+            update_local_repo_version(repo, arch, version)
+            res = del
+        else
+            log(("Skipping: %s/%s/%s"):format(branch, repo, arch))
+        end
+    end
+    return res
+end
+
+----------------
+----- MAIN -----
+----------------
+local unflag = {}
+for _,branch in pairs(conf.branches) do
+    local db_file = ("%s/aports-%s.db"):format(conf.db.path, branch)
+    db = sqlite.open(db_file)
+    create_tables()
+    db:exec("PRAGMA foreign_keys=ON")
+    db:exec("PRAGMA journal_mode=WAL")
+    db:exec("begin")
+    for _,repo in pairs(conf.repos) do
+        for _,arch in pairs(conf.archs) do
+            local del = update(branch, repo, arch)
+            if branch == conf.default.branch then
+                for _,v in pairs(del) do
+                    local k = ("%s-%s-%s"):format(v.repo, v.origin, v.version)
+                    unflag[k] = {repo=v.repo, origin=v.origin, version=v.version}
                 end
             end
         end
     end
-    self:log("Update finished.")
+    if branch == conf.default.branch then
+        create_flagged_table()
+        update_flagged(unflag)
+    end
+    db:exec("commit")
+    db:exec("PRAGMA wal_checkpoint(TRUNCATE)")
+    db:close()
 end
-
-local import = import()
-import:run()
-import:finalize()
+log("Update finished.")

--- a/tools/migrate_v2.lua
+++ b/tools/migrate_v2.lua
@@ -1,0 +1,77 @@
+#!/usr/bin/luajit
+
+local sqlite = require("lsqlite3")
+local gver = require("gversion")
+
+local pre_suffixes = {'alpha', 'beta', 'pre', 'rc'}
+gver.set_suffixes(pre_suffixes, {'cvs', 'svn', 'git', 'hg', 'p'})
+
+local conf = require("config")
+
+local original_db = "db/aports.db"
+local flagged_db = "db/flagged.db"
+
+local db = sqlite.open(original_db)
+local fdb = sqlite.open(flagged_db)
+
+fdb:exec([[
+    CREATE TABLE IF NOT EXISTS 'flagged' (
+        'origin' TEXT,
+        'version' TEXT,
+        'repo' TEXT,
+        'created' INTEGER,
+        'updated' INTEGER,
+        'reporter' TEXT,
+        'new_version' TEXT,
+        'message' TEXT,
+        PRIMARY KEY ('origin', 'version', 'repo')
+    ) WITHOUT ROWID
+]])
+
+fdb:close()
+
+db:exec(("ATTACH DATABASE %q as new"):format(flagged_db))
+
+db:exec(([[
+    INSERT INTO new.flagged (
+        origin, version, repo, created, reporter, new_version, message
+    )
+    SELECT packages.origin, packages.version, packages.repo, flagged.created,
+    flagged.reporter, flagged.new_version, flagged.message
+    FROM flagged
+    JOIN packages ON flagged.fid = packages.fid
+    GROUP BY packages.origin
+]]))
+
+
+-- check if current version in default arch (which is the most up to date)
+-- is higher then the flagged version and update flagged entry if true.
+local sql = ([[
+    SELECT f.repo as repo, f.origin as origin, f.version as fversion,
+    p.build_time as build_time, p.version as pversion
+    FROM new.flagged f
+    JOIN packages p
+    ON p.origin = f.origin
+    AND p.repo = f.repo
+    WHERE p.arch = %q
+    AND p.branch = %q
+    GROUP BY p.origin
+]]):format(conf.default.arch, conf.default.branch)
+
+db:exec("begin")
+for row in db:nrows(sql) do
+    -- we need to normalize as some pkgs in aports are not following
+    -- gentoo versioning.
+    local pversion = gver(gver.normalize(row.pversion))
+    local fversion = gver(gver.normalize(row.fversion))
+    if pversion and fversion and pversion > fversion then
+        db:exec(([[
+            UPDATE new.flagged SET updated = %q
+            WHERE repo = %q
+            AND origin = %q
+            AND version = %q
+        ]]):format(row.build_time, row.repo, row.origin, row.fversion))
+    end
+end
+db:exec("commit")
+db:close()

--- a/utils.lua
+++ b/utils.lua
@@ -78,4 +78,38 @@ function M.parse_email_addr(addr)
     end
 end
 
+function M.in_table(e, t)
+    for _,v in pairs(t) do
+        if (v==e) then return true end
+    end
+    return false
+end
+
+---
+-- copy table to a new table and optional filter keys
+function M.copy_table(tbl, fk)
+    local res = {}
+    for k,v in pairs(tbl) do
+        if type(fk) == "table" and not M.in_table(k, fk) then
+            res[k] = v
+        end
+    end
+    return res
+end
+
+function M.file_exists(path)
+    local f = io.open(path, "r")
+    if f ~= nil then
+        io.close(f)
+        return true
+    end
+    return false
+end
+
+function M.split(s,d)
+    local r = {}
+    for i in s:gmatch(d) do table.insert(r,i) end
+    return r
+end
+
 return M

--- a/views/flag.tpl
+++ b/views/flag.tpl
@@ -41,7 +41,6 @@
                                             <tr><th>Origin name</th><td>{{origin}}</td></tr>
                                             <tr><th>Repository</th><td>{{repo}}</td></tr>
                                             <tr><th>Version</th><td>{{version}}</td></tr>
-                                            <tr><th>Maintainer</th><td>{{maintainer}}</td></tr>
                                         </tbody>
                                     </table>
                                     <div class="alert alert-warning" role="alert">Flagging a package out of date will always select the orgin package. This means if you have selected another package to flag this is most probably a subpackage of ({{origin}})</div>

--- a/views/flagged.tpl
+++ b/views/flagged.tpl
@@ -18,13 +18,6 @@
                         </div>
                     </div>
                     <div class="form-group">
-                        <select name="branch" data-placeholder="Branch" class="form-control chosen-select" id="branch" >
-                        {{#form.branch}}
-                            <option {{{selected}}} >{{text}}</option>
-                        {{/form.branch}}
-                        </select>
-                    </div>
-                    <div class="form-group">
                         <select name="repo" data-placeholder="Repository" class="form-control chosen-select" id="repo">
                         {{#form.repo}}
                             <option {{{selected}}} >{{text}}</option>
@@ -47,7 +40,6 @@
                         <th>Origin</th>
                         <th>Version</th>
                         <th>New version</th>
-                        <th>Branch</th>
                         <th>Repository</th>
                         <th>Maintainer</th>
                         <th>Flag date</th>
@@ -60,8 +52,7 @@
                         </td>
                         <td class="version text-danger"><strong>{{version}}</strong></td>
                         <td class="new_version">{{new_version}}</td>
-                        <td class="branch">{{branch}}</td>
-                        <td class="branch">{{repo}}</td>
+                        <td class="repo">{{repo}}</td>
                         <td class="maintainer">{{maintainer}}</td>
                         <td class="created">{{created}}</td>
                         <td class="message text-center">

--- a/views/package.tpl
+++ b/views/package.tpl
@@ -24,9 +24,14 @@
                                             <tr>
                                                 <th class="text-nowrap">Version</th>
                                                 <td>
+                                                    {{#pkg.flaggable}}
                                                     <strong>
                                                         <a data-toggle="tooltip" title="{{pkg.version.title}}" class="{{pkg.version.class}}" href="{{pkg.version.path}}">{{pkg.version.text}}</a>
                                                     <strong>
+                                                    {{/pkg.flaggable}}
+                                                    {{^pkg.flaggable}}
+                                                        {{pkg.version.text}}
+                                                    {{/pkg.flaggable}}
                                                 </td>
                                             </tr>
                                             <tr>

--- a/views/packages.tpl
+++ b/views/packages.tpl
@@ -65,6 +65,7 @@
                         <td class="package">
                             <a data-toggle="tooltip" title="{{name.title}}" href="{{name.path}}">{{name.text}}</a>
                         </td>
+                        {{#default}}
                         {{#flagged}}
                         <td class="version">
                             <strong>
@@ -79,6 +80,10 @@
                             </strong>
                         </td>
                         {{/flagged}}
+                        {{/default}}
+                        {{^default}}
+                        <td class="version">{{version.text}}</td>
+                        {{/default}}
                         <td class="url"><a href="{{url.path}}">{{url.text}}</a></td>
                         <td class="license">{{license}}</td>
                         <td class="branch">{{branch}}</td>


### PR DESCRIPTION
- split databases into branches
- move flagged table to separate db read-write
- set branch databases as read-only (from webif)
- change relation of pkg vs flagged status
- added migration script to migrate to new flagged table format
- added new provider_priority field to apk header
- add settings for default branch and arch
- make edge the default branch in packages list
- add SQL debug option in config
- remove uneeded usage of class
- move all utils to utils.lua
- optimize SQL queries
- re-factor importer script
- allow to change http listening port via environment

This commit changes how we handle databases. Instead of having
everything in a single sqlite database we split each branch into its own
sqlite database. This will limit the amount of rows in the pkg/file per
table and improve performance.

Flagged table has also been moved to its own database and has been
redesigned. Splitting it into its own db makes it possible to open the
branch databases read-only. This redesign creates a new composite index
(repo,origin,version) so the packages table is now related to this index
which makes it possible to remove the current flag id column. This also
introduced the updated column to be able to unflag a package and make it
unlisted on flagged listing but still be able to show the status on
individual packages when some archs are behind. Every time packages are
updated the unique triple will be looked up in the flagged table and
updated/unflagged when found.

Migration is handled by the migrate_v2.lua script. It needs to be run
against the old single aports.db and will generate a single flagged.db
after which the import script can be run to start generating the
splitted aports-branch.dbs. Some settings need to be updated from the
provided sample config ie the db location is changed to a path instead
of a file and the apkindex format is now defined in config instead of
hard coded in multiple places.