### PR TITLE
tools/import.lua: fix 'flagged' table name

### DIFF
--- a/tools/import.lua
+++ b/tools/import.lua
@@ -97,7 +97,7 @@ end
 local function create_flagged_table()
     if conf.db.init ~= true then return true end
     db:exec([[
-        CREATE TABLE IF NOT EXISTS 'flagged.flagged' (
+        CREATE TABLE IF NOT EXISTS 'flagged' (
             'origin' TEXT,
             'version' TEXT,
             'repo' TEXT,


### PR DESCRIPTION
Hi,

An error was occurring when running the import script with `config.db.init = true`:

```
Function: update_flagged
Database error: no such table: flagged
SQL Query:
        UPDATE flagged SET updated = strftime('%s', 'now')
        WHERE repo = :repo
        AND origin = :origin
        AND version = :version

luajit: tools/import.lua:416: attempt to index local 'stmt' (a nil value)
stack traceback:
        tools/import.lua:416: in function 'update_flagged'
        tools/import.lua:463: in main chunk
        [C]: at 0x55a63415fc6e
```

Changing it from `flagged.flagged` to `flagged` fixed it.

Regards,
Tiago.