### PR TITLE
Add form filters links

### DIFF
--- a/aports.lua
+++ b/aports.lua
@@ -99,7 +99,7 @@ function flagRenderer:post(repo, origin, version)
         m.form.message = {class="input-error"}
         self:write(cntrl.flag(pkg, m))
     -- check if recaptcha is correct
-    elseif conf.rc.sitekey and not cntrl.verifyRecaptcha(args.responce) then
+    elseif conf.rc.enabled and not cntrl.verifyRecaptcha(args.responce) then
         m.alert = {type="danger",msg="reCAPTCHA failed, please try again"}
         self:write(cntrl.flag(pkg, m))
     -- try to flag the package

--- a/controller.lua
+++ b/controller.lua
@@ -204,9 +204,13 @@ function cntrl.createPager(total, limit, current, offset)
 end
 
 ----
--- verify recaptch responce
+-- verify recaptcha response
 ----
 function cntrl.verifyRecaptcha(response)
+    if conf.rc.sitekey == "" then
+        turbo.log.warning("reCAPTCHA site key not found.")
+        return true
+    end
     local uri = "https://www.google.com/recaptcha/api/siteverify"
     local kwargs = {}
     kwargs.method = "POST"

--- a/controller.lua
+++ b/controller.lua
@@ -32,6 +32,7 @@ end
 function cntrl.packages(args)
     db:select(args.branch)
     local m = {}
+    m.args = args
     -- get packages
     local offset = (args.page - 1) * conf.pager.limit
     local pkgs = db:getPackages(args, offset)
@@ -93,6 +94,7 @@ end
 function cntrl.contents(args)
     db:select(args.branch)
     local m = {}
+    m.args = args
     -- navigation menu
     m.nav = {content="active"}
     -- search form
@@ -143,6 +145,7 @@ end
 function cntrl.flagged(args, m)
     db:select(conf.default.branch)
     m = m or {}
+    m.args = args
     -- get packages
     local offset = (args.page - 1) * conf.pager.limit
     local pkgs, qty = db:getFlagged(args, offset)

--- a/model.lua
+++ b/model.lua
@@ -39,9 +39,19 @@ function model.packages(pkgs, branch)
         }
         r[k].license = v.license
         r[k].branch = branch
-        r[k].arch = v.arch
-        r[k].repo = v.repo
-        r[k].maintainer = v.mname or "None"
+        r[k].arch = {
+            text=v.arch,
+            title=string.format("Filter packages in the %s architecture", v.arch)
+        }
+        r[k].repo = {
+            text=v.repo,
+            title=string.format("Filter packages in the %s repository", v.repo)
+        }
+        maintainer = v.mname or "None"
+        r[k].maintainer = {
+            text=maintainer,
+            title=string.format("Filter packages maintained by %s", maintainer)
+        }
         r[k].build_time = v.build_time
         if (v.flagged) then
             r[k].version.title = "Flagged: "..v.flagged
@@ -141,8 +151,15 @@ function model.flagged(pkgs)
         r[k].version = v.version
         r[k].new_version = v.new_version
         r[k].arch = v.arch
-        r[k].repo = v.repo
-        r[k].maintainer = v.mname or "None"
+        r[k].repo = {
+            text=v.repo,
+            title=string.format("Filter packages in the %s repository", v.repo)
+        }
+        maintainer = v.mname or "None"
+        r[k].maintainer = {
+            text=maintainer,
+            title=string.format("Filter packages maintained by %s", maintainer)
+        }
         r[k].created = v.created
         r[k].message = v.message
         r[k].class = "hint--"..class.."-left hint--medium hint--rounded"
@@ -202,8 +219,14 @@ function model.contents(cnt, branch)
     for k,v in pairs(cnt) do
         r[k] = {}
         r[k].branch = branch
-        r[k].repo = v.repo
-        r[k].arch = v.arch
+        r[k].repo = {
+            text=v.repo,
+            title=string.format("Filter packages in the %s repository", v.repo)
+        }
+        r[k].arch = {
+            text=v.arch,
+            title=string.format("Filter packages in the %s architecture", v.arch)
+        }
         r[k].file = string.format("%s/%s", v.path, v.file)
         r[k].pkgname = {}
         r[k].pkgname.path = string.format("/package/%s/%s/%s/%s", branch, v.repo, v.arch, v.name)

--- a/views/contents.tpl
+++ b/views/contents.tpl
@@ -64,8 +64,16 @@
                             <td>{{file}}</td>
                             <td><a href="{{pkgname.path}}">{{pkgname.text}}</a></td>
                             <td>{{branch}}</td>
-                            <td>{{repo}}</td>
-                            <td>{{arch}}</td>
+                            <td class="repo">
+                                <a class="hint--right" aria-label="{{repo.title}}" href="?file={{args.file}}&path={{args.path}}&name={{args.name}}&branch={{args.branch}}&repo={{repo.text}}&arch={{args.arch}}">
+                                    {{repo.text}}
+                                </a>
+                            </td>
+                            <td class="arch">
+                                <a class="hint--right" aria-label="{{arch.title}}" href="?file={{args.file}}&path={{args.path}}&name={{args.name}}&branch={{args.branch}}&repo={{args.repo}}&arch={{arch.text}}">
+                                    {{arch.text}}
+                                </a>
+                            </td>
                         </tr>
                         {{/contents}}
                         {{^contents}}

--- a/views/flagged.tpl
+++ b/views/flagged.tpl
@@ -54,8 +54,16 @@
                             </td>
                             <td class="version text-danger"><strong>{{version}}</strong></td>
                             <td class="new_version">{{new_version}}</td>
-                            <td class="repo">{{repo}}</td>
-                            <td class="maintainer">{{maintainer}}</td>
+                            <td class="repo">
+                                <a class="hint--right" aria-label="{{repo.title}}" href="?origin={{args.origin}}&repo={{repo.text}}&maintainer={{args.maintainer}}">
+                                    {{repo.text}}
+                                </a>
+                            </td>
+                            <td class="maintainer">
+                                <a class="hint--right" aria-label="{{maintainer.title}}" href="?origin={{args.origin}}&repo={{args.repo}}&maintainer={{maintainer.text}}">
+                                    {{maintainer.text}}
+                                </a>
+                            </td>
                             <td class="created">{{created}}</td>
                             <td class="message">
                                 <div class="{{class}}" aria-label="{{message}}">

--- a/views/packages.tpl
+++ b/views/packages.tpl
@@ -83,9 +83,21 @@
                         <td class="url"><a href="{{url.path}}">{{url.text}}</a></td>
                         <td class="license">{{license}}</td>
                         <td class="branch">{{branch}}</td>
-                        <td class="repo">{{repo}}</td>
-                        <td class="arch">{{arch}}</td>
-                        <td class="maintainer">{{maintainer}}</td>
+                        <td class="repo">
+                            <a class="hint--right" aria-label="{{repo.title}}" href="?name={{args.name}}&branch={{args.branch}}&repo={{repo.text}}&arch={{args.arch}}&maintainer={{args.maintainer}}">
+                                {{repo.text}}
+                            </a>
+                        </td>
+                        <td class="arch">
+                            <a class="hint--right" aria-label="{{arch.title}}" href="?name={{args.name}}&branch={{args.branch}}&repo={{args.repo}}&arch={{arch.text}}&maintainer={{args.maintainer}}">
+                                {{arch.text}}
+                            </a>
+                        </td>
+                        <td class="maintainer">
+                            <a class="hint--right" aria-label="{{maintainer.title}}" href="?name={{args.name}}&branch={{args.branch}}&repo={{args.repo}}&arch={{args.arch}}&maintainer={{maintainer.text}}">
+                                {{maintainer.text}}
+                            </a>
+                        </td>
                         <td class="bdate">{{build_time}}</td>
                     </tr>
                     {{/pkgs}}


### PR DESCRIPTION
Hi,

I always (intuitively) tried to click on the Repository/Architecture/Maintainer columns to filter the list. Links were added to them, allowing the same form filters to be applied in a simpler/quicker way.

Regards,
Tiago.